### PR TITLE
Allow always starting from zero cell if possible

### DIFF
--- a/src/Minesweeper.ts
+++ b/src/Minesweeper.ts
@@ -195,7 +195,7 @@ class Minesweeper {
       return { x: -1, y: -1 };
     }
 
-    const zeroCells = this.safeCells.filter(c => this.matrix[c.x][c.y] == this.types.numbers[0]);
+    const zeroCells = this.safeCells.filter(c => this.matrix[c.x][c.y] === this.types.numbers[0]);
     if (this.zeroFirstCell && zeroCells.length > 0) {
       const safeCell: SafeCell = zeroCells[Math.floor(Math.random() * zeroCells.length)];
 
@@ -241,7 +241,7 @@ class Minesweeper {
     for (let i = xLower; i <= xUpper; i++) {
       for (let j = yLower; j <= yUpper; j++) {
         if (isSpoiler(i, j)) {
-          if (this.matrix[i][j] == this.types.numbers[0]) {
+          if (this.matrix[i][j] === this.types.numbers[0]) {
             zeroCells.push({ x: i, y: j });
           }
           this.matrix[i][j] = this.matrix[i][j].slice(2, -2);
@@ -249,7 +249,9 @@ class Minesweeper {
       }
     }
 
-    if (recurse) zeroCells.forEach(c => this.revealSurroundings(c, true));
+    if (recurse) {
+      zeroCells.forEach(c => this.revealSurroundings(c, true));
+    }
   }
 
   /**

--- a/src/Minesweeper.ts
+++ b/src/Minesweeper.ts
@@ -195,8 +195,8 @@ class Minesweeper {
       return { x: -1, y: -1 };
     }
 
-    if (this.zeroFirstCell) {
-      const zeroCells = this.safeCells.filter(c => this.matrix[c.x][c.y] == this.types.numbers[0]);
+    const zeroCells = this.safeCells.filter(c => this.matrix[c.x][c.y] == this.types.numbers[0]);
+    if (this.zeroFirstCell && zeroCells.length > 0) {
       const safeCell: SafeCell = zeroCells[Math.floor(Math.random() * zeroCells.length)];
 
       const x: number = safeCell.x;


### PR DESCRIPTION
At least newer versions of minesweeper usually guarantee your first square is a zero cell, and automatically reveal all cells around any zero cell the player clicks on. While the latter can't really be done with discord spoilers during the game, forcing a start from zero is possible (assuming a zero cell exists), and pre-revealing cells from that point is as well.

This PR adds an option, `zeroFirstCell`, which will enable both of these behaviours. It is by default set to `true`, but won't do anything if `revealFirstCell` is `false`.

Currently there is no option to disable the recursive reveal feature, as I didn't consider it necessary, but it would be easy to implement if desired.

If there are no zero cells in the grid, this automatically falls back to the normal behaviour (i.e. revealing a random `SafeCell`).